### PR TITLE
Update berlin-transport-card.js

### DIFF
--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -34,7 +34,7 @@ class BerlinTransportCard extends HTMLElement {
             }
 
             const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
-            const delay = departure.delay === 'null' ? `` : departure.delay / 60;
+            const delay = departure.delay === null ? `` : departure.delay / 60;
             const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
             const currentDate = new Date().getTime();
             const timestamp = new Date(departure.timestamp).getTime();
@@ -134,6 +134,8 @@ class BerlinTransportCard extends HTMLElement {
             .delay {
                line-height: 2em;
                font-size: 70%;
+               text-align: right;
+               min-width: 1.5em;
             }
             .delay-pos {
                color: #8B0000;

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -135,7 +135,7 @@ class BerlinTransportCard extends HTMLElement {
                line-height: 2em;
                font-size: 70%;
                text-align: right;
-               min-width: 1.5em;
+               min-width: 2ch;
             }
             .delay-pos {
                color: #8B0000;


### PR DESCRIPTION
Currently when no real time / delay informations are available "+0" is displayed for delay:
- Fixed checking for missing delay/real time information
- Modified css layout of delay class to handle empty real times

I hope I'm on the right path with that fix.