### PR TITLE
Support Sections layout

### DIFF
--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -78,7 +78,7 @@ class BerlinTransportCard extends HTMLElement {
             ha-card {
                 height: 100%;
                 padding: 10px;
-                line-height: 1.5em;
+                line-height: 2em;
             }
             .container {
                 height: 100%;
@@ -87,13 +87,14 @@ class BerlinTransportCard extends HTMLElement {
             .stop {
                 opacity: 0.6;
                 text-align: left;
-                padding: 10px 10px 5px 5px;
+                padding: 10px 10px 10px 5px;
             }
             .departures {
-                padding-bottom: 20px;
+                padding-bottom: 10px;
             }
             .departure {
-                padding-top: 10px;
+                padding-top: 2px;
+                padding-bottom: 10px;
                 display: flex;
                 flex-direction: row;
                 flex-wrap: nowrap;

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -34,28 +34,28 @@ class BerlinTransportCard extends HTMLElement {
             }
 
             const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
-            const delay = departure.delay === null ? `` : departure.delay / 60;
-            const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
-            const currentDate = new Date().getTime();
-            const timestamp = new Date(departure.timestamp).getTime();
-            const walkingTime = includeWalkingTime ? departure.walking_time : 0;
-            const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
-            const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
+                const delay = departure.delay === null ? `` : departure.delay / 60;
+                const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
+                const currentDate = new Date().getTime();
+                const timestamp = new Date(departure.timestamp).getTime();
+                const walkingTime = includeWalkingTime ? departure.walking_time : 0;
+                const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
+                const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
-            return departure.cancelled && !showCancelled ? `` :
-                `<div class="${departure.cancelled ? 'departure-cancelled' : 'departure'}">
-                    <div class="line">
-                        <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
-                    </div>
-                    <div class="direction">${departure.direction}</div>
-                    <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
-                </div>`
+                return departure.cancelled && !showCancelled ? `` :
+                    `<div class="${departure.cancelled ? 'departure-cancelled' : 'departure'}">
+                        <div class="line">
+                            <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
+                        </div>
+                        <div class="direction">${departure.direction}</div>
+                        <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
+                    </div>`
             });
 
             content += `<div class="departures">` + timetable.join("\n") + `</div>`;
         }
 
-       this.shadowRoot.getElementById('container').innerHTML = content;
+        this.shadowRoot.getElementById('container').innerHTML = content;
     }
 
     /* This is called only when config is updated */
@@ -68,7 +68,7 @@ class BerlinTransportCard extends HTMLElement {
         const card = document.createElement('ha-card');
         const content = document.createElement('div');
         const style = document.createElement('style');
-  
+
         style.textContent = `
             .container {
                 padding: 10px;
@@ -81,7 +81,7 @@ class BerlinTransportCard extends HTMLElement {
                 width: 100%;
                 text-align: left;
                 padding: 10px 10px 5px 5px;
-            }      
+            }
             .departures {
                 width: 100%;
                 font-weight: 400;
@@ -147,7 +147,7 @@ class BerlinTransportCard extends HTMLElement {
                font-style: italic;
             }
         `;
-     
+
         content.id = "container";
         content.className = "container";
         card.header = config.title;
@@ -155,11 +155,11 @@ class BerlinTransportCard extends HTMLElement {
         card.appendChild(content);
 
         root.appendChild(card);
-      }
-  
+    }
+
     // The height of the card.
     getCardSize() {
-      return 5;
+        return 5;
     }
 }
   

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -75,10 +75,15 @@ class BerlinTransportCard extends HTMLElement {
         const style = document.createElement('style');
 
         style.textContent = `
-            .container {
+            ha-card {
+                height: 100%;
                 padding: 10px;
                 font-size: 130%;
                 line-height: 1.5em;
+            }
+            .container {
+                height: 100%;
+                overflow: hidden hidden;
             }
             .stop {
                 opacity: 0.6;
@@ -154,6 +159,13 @@ class BerlinTransportCard extends HTMLElement {
     // The height of the card.
     getCardSize() {
         return 5;
+    }
+
+    // The rules for sizing your card in the grid in sections view
+    getGridOptions() {
+        return {
+            rows: 5,
+        };
     }
 }
   

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -43,7 +43,7 @@ class BerlinTransportCard extends HTMLElement {
                     const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
                     return departure.cancelled && !showCancelled ? `` :
-                        `<div class="${departure.cancelled ? 'departure-cancelled' : 'departure'}">
+                        `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
                             <div class="line">
                                 <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
                             </div>
@@ -82,15 +82,10 @@ class BerlinTransportCard extends HTMLElement {
             }
             .stop {
                 opacity: 0.6;
-                font-weight: 400;
-                width: 100%;
                 text-align: left;
                 padding: 10px 10px 5px 5px;
             }
             .departures {
-                width: 100%;
-                font-weight: 400;
-                line-height: 1.5em;
                 padding-bottom: 20px;
             }
             .departure {
@@ -104,12 +99,6 @@ class BerlinTransportCard extends HTMLElement {
             .departure-cancelled {
                 text-decoration: line-through;
                 filter: grayscale(50%);
-                padding-top: 10px;
-                display: flex;
-                flex-direction: row;
-                flex-wrap: nowrap;
-                align-items: flex-start;
-                gap: 20px;
             }
             .line {
                 min-width: 70px;
@@ -137,8 +126,8 @@ class BerlinTransportCard extends HTMLElement {
                 display: flex;
             }
             .delay {
-               line-height: 2em;
                font-size: 70%;
+               line-height: 2em;
                text-align: right;
                min-width: 2ch;
             }

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -78,7 +78,6 @@ class BerlinTransportCard extends HTMLElement {
             ha-card {
                 height: 100%;
                 padding: 10px;
-                font-size: 130%;
                 line-height: 1.5em;
             }
             .container {

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -83,6 +83,7 @@ class BerlinTransportCard extends HTMLElement {
             .container {
                 height: 100%;
                 overflow: hidden hidden;
+                margin-bottom: -10px;
             }
             .stop {
                 opacity: 0.6;


### PR DESCRIPTION
This PR add support for the "new" Sections layout for dashboards. It requires that the card uses the configured size or the layout is broken.

This also adjusts the margins, so that the card tries to support all odd heights in the Sections layout without cutting of a departure (at least if the destination fit in one line). 

<img width="387" height="62" alt="image" src="https://github.com/user-attachments/assets/1be19edc-cbab-48e0-9ae6-f84e7086d7af" /><br>
<img width="386" height="196" alt="image" src="https://github.com/user-attachments/assets/46fb4e3e-c93d-4cbe-85d6-aab4db34e110" /><br>
<img width="379" height="321" alt="image" src="https://github.com/user-attachments/assets/5227ecf4-b808-4bf4-b8bd-db401fa8950f" /><br>
<img width="499" height="452" alt="image" src="https://github.com/user-attachments/assets/ec360a50-835f-4638-b120-2f0cb29a4752" />

With the section layout you can combine multiple cards with a heading without relying on the integrated support for multiple stops (just as an example with the same stop multiple times):

<img width="809" height="509" alt="image" src="https://github.com/user-attachments/assets/a3984034-b24a-4af9-aaf1-3f1bcddee350" />


In the Masonry layout the card automatically resizes to fit the content as before.

