### PR TITLE
Show error if sensor unavailable (due to API error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This Lovelace card can be installed via [HACS](https://hacs.xyz/) or manually.
   show_absolute_time: true # show the absolute time till departure.
   show_relative_time: true # show the relative time till departure.
   include_walking_time: true # subtract walking time to the stop from the relative time to the departure.
+  show_warnings: true # show or hide the service warnings if reported. When not defined or true, the warnings will be shown under the direction.
 ```
 
 

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -20,6 +20,7 @@ class BerlinTransportCard extends HTMLElement {
         const showAbsoluteTime = config.show_absolute_time || (config.show_absolute_time === undefined);
         const showRelativeTime = config.show_relative_time || (config.show_relative_time === undefined);
         const includeWalkingTime = config.include_walking_time || (config.include_walking_time === undefined);
+        const showWarnings = config.show_warnings || (config.show_warnings === undefined);
 
         let content = "";
 
@@ -42,12 +43,19 @@ class BerlinTransportCard extends HTMLElement {
                     const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
                     const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
+                    const warnings = departure.warnings || [];
+                    const warningsDiv = showWarnings && warnings.length > 0 ?
+                        `<div class="warnings">${warnings.map(w => `<div class="warning-item"><ha-icon icon="mdi:alert-circle" class="warning-icon"></ha-icon>${w.summary}</div>`).join("")}</div>` : '';
+
                     return departure.cancelled && !showCancelled ? `` :
                         `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
                             <div class="line">
                                 <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
                             </div>
-                            <div class="direction">${departure.direction}</div>
+                            <div class="direction">
+                                ${departure.direction}
+                                ${warningsDiv}
+                            </div>
                             <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
                         </div>`
                 });
@@ -146,6 +154,23 @@ class BerlinTransportCard extends HTMLElement {
             .relative-time {
                font-style: italic;
             }
+            .warnings {
+                display: flex;
+                flex-direction: column;
+                gap: 2px;
+                padding-top: 5px;
+            }
+            .warning-item {
+                font-size: 80%;
+                line-height: 1.2em;
+                color: var(--warning-color, #ff9800);
+                display: flex;
+                align-items: center;
+                gap: 4px;
+            }
+            .warning-icon {
+                --mdc-icon-size: 14px;
+            }
         `;
 
         content.id = "container";
@@ -183,6 +208,7 @@ class BerlinTransportCard extends HTMLElement {
             show_absolute_time: true,
             show_relative_time: true,
             include_walking_time: false,
+            show_warnings: true,
         }
     }
 }
@@ -204,7 +230,8 @@ class BerlinTransportCardEditor extends HTMLElement {
             show_delay: "Show delay",
             show_absolute_time: "Show absolute time of departures",
             show_relative_time: "Show relative time of departures",
-            include_walking_time: "Subtract walking time from relative time of departures"
+            include_walking_time: "Subtract walking time from relative time of departures",
+            show_warnings: "Show warnings (e.g. service disruptions)"
         };
 
         return labels[field.name] ? labels[field.name] : field.name;
@@ -229,6 +256,7 @@ class BerlinTransportCardEditor extends HTMLElement {
             { name: "show_absolute_time", selector: { boolean: {} }},
             { name: "show_relative_time", selector: { boolean: {} }},
             { name: "include_walking_time", selector: { boolean: {} }},
+            { name: "show_warnings", selector: { boolean: {} }},
         ];
         form.computeLabel = this._computeLabel;
         form.addEventListener("value-changed", this._valueChanged);

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -34,29 +34,81 @@ class BerlinTransportCard extends HTMLElement {
                     content += `<div class="stop">${entity.attributes.friendly_name}</div>`;
                 }
 
-                const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
+                const departures = entity.attributes.departures.slice(0, maxEntries);
+                const warningCounts = {};
+                const warningObjects = {};
+
+                // Pre-process warnings: filter redundant and count occurrences
+                departures.forEach((departure) => {
+                    if (departure.cancelled && !showCancelled) return;
+                    let warnings = departure.warnings || [];
+                    if (typeof warnings === 'object' && !Array.isArray(warnings)) warnings = [warnings];
+                    
+                    const seenInThisDeparture = new Set();
+                    warnings.forEach(w => {
+                        const summary = typeof w === 'object' ? w.summary : w;
+                        if (summary && (summary.toLowerCase() === 'trip canceled' || summary.toLowerCase() === 'trip cancelled')) return;
+                        
+                        const id = typeof w === 'object' ? (w.id || w.summary) : w;
+                        if (seenInThisDeparture.has(id)) return;
+                        seenInThisDeparture.add(id);
+
+                        warningCounts[id] = (warningCounts[id] || 0) + 1;
+                        warningObjects[id] = w;
+                    });
+                });
+
+                // Global warnings (appear in more than one line)
+                const globalWarnings = Object.keys(warningCounts).filter(id => warningCounts[id] > 1);
+                if (showWarnings && globalWarnings.length > 0) {
+                    content += `<div class="warnings global-warnings">` +
+                        globalWarnings.map(id => {
+                            const w = warningObjects[id];
+                            const summary = typeof w === 'object' ? w.summary : w;
+                            return `<div class="warning-item"><ha-icon icon="mdi:alert-circle" class="warning-icon"></ha-icon>${summary}</div>`;
+                        }).join("") +
+                        `</div>`;
+                }
+
+                const timetable = departures.map((departure) => {
+                    if (departure.cancelled && !showCancelled) return "";
+
                     const delay = departure.delay === null ? `` : departure.delay / 60;
                     const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
                     const currentDate = new Date().getTime();
                     const timestamp = new Date(departure.timestamp).getTime();
-                    const walkingTime = includeWalkingTime ? departure.walking_time : 0;
+                    const walkingTime = includeWalkingTime ? (departure.walking_time || 0) : 0;
                     const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
                     const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
-                    const warnings = departure.warnings || [];
-                    const warningsDiv = showWarnings && warnings.length > 0 ?
-                        `<div class="warnings">${warnings.map(w => `<div class="warning-item"><ha-icon icon="mdi:alert-circle" class="warning-icon"></ha-icon>${w.summary}</div>`).join("")}</div>` : '';
+                    let warnings = departure.warnings || [];
+                    if (typeof warnings === 'object' && !Array.isArray(warnings)) warnings = [warnings];
+                    
+                    // Filter: keep only if it's NOT a global warning and NOT a "Trip canceled" warning
+                    const localWarnings = warnings.filter(w => {
+                        const summary = typeof w === 'object' ? w.summary : w;
+                        if (summary && (summary.toLowerCase() === 'trip canceled' || summary.toLowerCase() === 'trip cancelled')) return false;
+                        const id = typeof w === 'object' ? (w.id || w.summary) : w;
+                        return warningCounts[id] === 1;
+                    });
 
-                    return departure.cancelled && !showCancelled ? `` :
-                        `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
-                            <div class="line">
+                    const warningsDiv = showWarnings && localWarnings.length > 0 ?
+                        `<div class="warnings">${localWarnings.map(w => {
+                            const summary = typeof w === 'object' ? w.summary : w;
+                            return `<div class="warning-item"><ha-icon icon="mdi:alert-circle" class="warning-icon"></ha-icon>${summary}</div>`;
+                        }).join("")}</div>` : '';
+
+                    const cancelledClass = departure.cancelled ? 'departure-cancelled' : '';
+
+                    return `<div class="departure">
+                            <div class="line ${cancelledClass}">
                                 <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
                             </div>
                             <div class="direction">
-                                ${departure.direction}
+                                <div class="${cancelledClass}">${departure.direction}</div>
                                 ${warningsDiv}
                             </div>
-                            <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
+                            <div class="time ${cancelledClass}">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
                         </div>`
                 });
 
@@ -131,6 +183,9 @@ class BerlinTransportCard extends HTMLElement {
             .direction {
                 align-self: center;
                 flex-grow: 1;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
             }
             .time {
                 align-self: flex-start;
@@ -170,6 +225,10 @@ class BerlinTransportCard extends HTMLElement {
             }
             .warning-icon {
                 --mdc-icon-size: 14px;
+            }
+            .global-warnings {
+                padding-bottom: 10px;
+                padding-left: 5px;
             }
         `;
 

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -60,9 +60,18 @@ class BerlinTransportCard extends HTMLElement {
 
                 // Global warnings (appear in more than one line)
                 const globalWarnings = Object.keys(warningCounts).filter(id => warningCounts[id] > 1);
-                if (showWarnings && globalWarnings.length > 0) {
+                const seenGlobalSummaries = new Set();
+                const uniqueGlobalWarnings = globalWarnings.filter(id => {
+                    const w = warningObjects[id];
+                    const summary = typeof w === 'object' ? w.summary : w;
+                    if (seenGlobalSummaries.has(summary)) return false;
+                    seenGlobalSummaries.add(summary);
+                    return true;
+                });
+
+                if (showWarnings && uniqueGlobalWarnings.length > 0) {
                     content += `<div class="warnings global-warnings">` +
-                        globalWarnings.map(id => {
+                        uniqueGlobalWarnings.map(id => {
                             const w = warningObjects[id];
                             const summary = typeof w === 'object' ? w.summary : w;
                             return `<div class="warning-item"><ha-icon icon="mdi:alert-circle" class="warning-icon"></ha-icon>${summary}</div>`;

--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -33,26 +33,30 @@ class BerlinTransportCard extends HTMLElement {
                     content += `<div class="stop">${entity.attributes.friendly_name}</div>`;
                 }
 
-                const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
-                    const delay = departure.delay === null ? `` : departure.delay / 60;
-                    const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
-                    const currentDate = new Date().getTime();
-                    const timestamp = new Date(departure.timestamp).getTime();
-                    const walkingTime = includeWalkingTime ? departure.walking_time : 0;
-                    const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
-                    const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
+                if (entity.state === "unavailable") {
+                    content += `<div class="not-found">No results due to API error.</div>`;
+                } else {
+                    const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
+                        const delay = departure.delay === null ? `` : departure.delay / 60;
+                        const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
+                        const currentDate = new Date().getTime();
+                        const timestamp = new Date(departure.timestamp).getTime();
+                        const walkingTime = includeWalkingTime ? departure.walking_time : 0;
+                        const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
+                        const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
-                    return departure.cancelled && !showCancelled ? `` :
-                        `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
-                            <div class="line">
-                                <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
-                            </div>
-                            <div class="direction">${departure.direction}</div>
-                            <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
-                        </div>`
-                });
+                        return departure.cancelled && !showCancelled ? `` :
+                            `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
+                                <div class="line">
+                                    <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
+                                </div>
+                                <div class="direction">${departure.direction}</div>
+                                <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
+                            </div>`
+                    });
 
-                content += `<div class="departures">` + timetable.join("\n") + `</div>`;
+                    content += `<div class="departures">` + timetable.join("\n") + `</div>`;
+                }
             }
         }
 


### PR DESCRIPTION
Show a message if the sensor is unavailable to due an API error. This is necessary for the custom component pull request vas3k/home-assistant-berlin-transport#66 to function properly. Currently, if the sensor is unavailable, the card just disappears from the UI and cannot be selected in edit mode at all.