### PR TITLE
Show error if sensor unavailable due to API error

### DIFF
--- a/dist/berlin-transport-card.js
+++ b/dist/berlin-transport-card.js
@@ -33,26 +33,30 @@ class BerlinTransportCard extends HTMLElement {
                     content += `<div class="stop">${entity.attributes.friendly_name}</div>`;
                 }
 
-                const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
-                    const delay = departure.delay === null ? `` : departure.delay / 60;
-                    const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
-                    const currentDate = new Date().getTime();
-                    const timestamp = new Date(departure.timestamp).getTime();
-                    const walkingTime = includeWalkingTime ? departure.walking_time : 0;
-                    const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
-                    const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
+                if (entity.state === "unavailable") {
+                    content += `<div class="not-found">No results due to API error.</div>`;
+                } else {
+                    const timetable = entity.attributes.departures.slice(0, maxEntries).map((departure) => {
+                        const delay = departure.delay === null ? `` : departure.delay / 60;
+                        const delayDiv = delay > 0 ? `<div class="delay delay-pos">+${delay}</div>`: `<div class="delay delay-neg">${delay === 0 ? '+0' : delay}</div>`;
+                        const currentDate = new Date().getTime();
+                        const timestamp = new Date(departure.timestamp).getTime();
+                        const walkingTime = includeWalkingTime ? departure.walking_time : 0;
+                        const relativeTime = Math.round((timestamp - currentDate) / (1000 * 60)) - walkingTime;
+                        const relativeTimeDiv = `<div class="relative-time">${relativeTime}&prime;&nbsp;</div>`;
 
-                    return departure.cancelled && !showCancelled ? `` :
-                        `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
-                            <div class="line">
-                                <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
-                            </div>
-                            <div class="direction">${departure.direction}</div>
-                            <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
-                        </div>`
-                });
+                        return departure.cancelled && !showCancelled ? `` :
+                            `<div class="departure ${departure.cancelled ? 'departure-cancelled' : ''}">
+                                <div class="line">
+                                    <div class="line-icon" style="background-color: ${departure.color}">${departure.line_name}</div>
+                                </div>
+                                <div class="direction">${departure.direction}</div>
+                                <div class="time">${showRelativeTime ? relativeTimeDiv : ''}${showAbsoluteTime ? departure.time : ''}${showDelay ? delayDiv : ''}</div>
+                            </div>`
+                    });
 
-                content += `<div class="departures">` + timetable.join("\n") + `</div>`;
+                    content += `<div class="departures">` + timetable.join("\n") + `</div>`;
+                }
             }
         }
 


### PR DESCRIPTION
Show a message if the sensor is unavailable to due an API error. This is necessary for the custom component pull request https://github.com/vas3k/home-assistant-berlin-transport/pull/66 to function properly. Currently, if the sensor is unavailable, the card just disappears from the UI and cannot be selected in edit mode at all.

Re-created after mistake in #15.

